### PR TITLE
add info parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ These files will be rendered and write to the output directory. Also, the genera
 You can use below variables in jinja2 template
 
 - `imports`  all imports statements
+- `info`  all info statements
 - `operations` `operations` is list of `operation`
   - `operation.type` HTTP METHOD
   - `operation.path` Path

--- a/fastapi_code_generator/__main__.py
+++ b/fastapi_code_generator/__main__.py
@@ -46,7 +46,7 @@ def generate_code(
     for target in template_dir.rglob("*"):
         relative_path = target.relative_to(template_dir.absolute())
         result = environment.get_template(str(relative_path)).render(
-            operations=parsed_object.operations, imports=parsed_object.imports
+            operations=parsed_object.operations, imports=parsed_object.imports, info=parsed_object.info
         )
         results[relative_path] = format_code(result, PythonVersion.PY_38)
 

--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -379,11 +379,12 @@ Path.update_forward_refs()
 
 
 class ParsedObject:
-    def __init__(self, parsed_operations: List[Operation]):
+    def __init__(self, parsed_operations: List[Operation], info=None):
         self.operations: List[Operation] = sorted(
             parsed_operations, key=lambda m: m.path
         )
         self.imports: Imports = Imports()
+        self.info = info
         for operation in self.operations:
             # create imports
             operation.arguments
@@ -412,8 +413,14 @@ class OpenAPIParser:
     ) -> Optional[List[Dict[str, List[str]]]]:
         return openapi.get('security')
 
+    def parse_info(
+        self, openapi: Dict[str, Any]
+    ) -> Optional[List[Dict[str, List[str]]]]:
+        return openapi.get('info')
+
     def parse_paths(self, openapi: Dict[str, Any]) -> ParsedObject:
         security = self.parse_security(openapi)
+        info = self.parse_info(openapi)
         return ParsedObject(
             [
                 operation
@@ -424,5 +431,6 @@ class OpenAPIParser:
                     security=security,
                     components=openapi.get('components', {}),
                 ).exists_operations
-            ]
+            ],
+            info
         )

--- a/fastapi_code_generator/template/main.jinja2
+++ b/fastapi_code_generator/template/main.jinja2
@@ -4,7 +4,13 @@ from fastapi import FastAPI
 
 {{imports}}
 
-app = FastAPI()
+app = FastAPI(
+    {% if info %}
+    {% for key,value in info.items() %}
+    {{ key }} = "{{ value }}",
+    {% endfor %}
+    {% endif %}
+    )
 
 
 {% for operation in operations %}


### PR DESCRIPTION
Added small modifications to enable parsing and passing the info block to jinja2 template.
Upstream adds no info, resulting in default FastAPI title on swagger docs page.
Tried running tests, but i'm getting exact same error on my branch as in master......so i guess pass? :wink: 