### PR TITLE
Remove excess code tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ $ fastapi-codegen --input api.yaml --output app
 <summary>api.yaml</summary>
 <pre>
 <code>
-```yaml
 openapi: "3.0.0"
 info:
   version: 1.0.0
@@ -181,7 +180,6 @@ components:
           format: int32
         message:
           type: string
-```
 </code>
 </pre>
 </details>


### PR DESCRIPTION
Looks like the readme contains double code tags; so this just removes the inner one

![image](https://user-images.githubusercontent.com/25310870/102597448-f3ca2b00-411a-11eb-8e9b-b29756bd1da3.png)
