### PR TITLE
Support multi-line string values for openapi keys

### DIFF
--- a/fastapi_code_generator/template/main.jinja2
+++ b/fastapi_code_generator/template/main.jinja2
@@ -7,7 +7,8 @@ from fastapi import FastAPI
 app = FastAPI(
     {% if info %}
     {% for key,value in info.items() %}
-    {{ key }} = """{{ value }}""",
+    {% set info_value= value.__repr__() %}
+    {{ key }} = {{info_value}},
     {% endfor %}
     {% endif %}
     )

--- a/fastapi_code_generator/template/main.jinja2
+++ b/fastapi_code_generator/template/main.jinja2
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 app = FastAPI(
     {% if info %}
     {% for key,value in info.items() %}
-    {{ key }} = "{{ value }}",
+    {{ key }} = """{{ value }}""",
     {% endfor %}
     {% endif %}
     )

--- a/tests/data/expected/openapi/default_template/body_and_parameters/main.py
+++ b/tests/data/expected/openapi/default_template/body_and_parameters/main.py
@@ -10,7 +10,12 @@ from fastapi import FastAPI, Query
 
 from .models import Pet, PetForm
 
-app = FastAPI(version="1.0.0", title="Swagger Petstore", license="{'name': 'MIT'}",)
+app = FastAPI(
+    version='1.0.0',
+    title='Swagger Petstore',
+    license={'name': 'MIT'},
+    description='This description is for testing\nmulti-line\ndescription\n',
+)
 
 
 @app.get('/foo', response_model=str)

--- a/tests/data/expected/openapi/default_template/oas_response_reference/main.py
+++ b/tests/data/expected/openapi/default_template/oas_response_reference/main.py
@@ -10,7 +10,12 @@ from fastapi import FastAPI
 
 from .models import Pet
 
-app = FastAPI(version="1.0.0", title="Swagger Petstore", license="{'name': 'MIT'}",)
+app = FastAPI(
+    version='1.0.0',
+    title='Swagger Petstore',
+    license={'name': 'MIT'},
+    description='This description is for testing\nmulti-line\ndescription\n',
+)
 
 
 @app.get('/pets', response_model=List[Pet])

--- a/tests/data/expected/openapi/default_template/simple/main.py
+++ b/tests/data/expected/openapi/default_template/simple/main.py
@@ -10,7 +10,12 @@ from fastapi import FastAPI, Query
 
 from .models import Pets
 
-app = FastAPI(version="1.0.0", title="Swagger Petstore", license="{'name': 'MIT'}",)
+app = FastAPI(
+    version='1.0.0',
+    title='Swagger Petstore',
+    license={'name': 'MIT'},
+    description='This description is for testing\nmulti-line\ndescription\n',
+)
 
 
 @app.get('/pets', response_model=Pets)

--- a/tests/data/expected/openapi/remote_ref/body_and_parameters/main.py
+++ b/tests/data/expected/openapi/remote_ref/body_and_parameters/main.py
@@ -10,7 +10,12 @@ from fastapi import FastAPI, Query
 
 from .models import Pet, PetForm
 
-app = FastAPI(version="1.0.0", title="Swagger Petstore", license="{'name': 'MIT'}",)
+app = FastAPI(
+    version='1.0.0',
+    title='Swagger Petstore',
+    license={'name': 'MIT'},
+    description='This description is for testing\nmulti-line\ndescription\n',
+)
 
 
 @app.get('/foo', response_model=str)

--- a/tests/data/openapi/default_template/body_and_parameters.yaml
+++ b/tests/data/openapi/default_template/body_and_parameters.yaml
@@ -4,6 +4,11 @@ info:
   title: Swagger Petstore
   license:
     name: MIT
+  description: |
+    This description is for testing
+    multi-line
+    description
+
 servers:
   - url: http://petstore.swagger.io/v1
 security:

--- a/tests/data/openapi/default_template/oas_response_reference.yaml
+++ b/tests/data/openapi/default_template/oas_response_reference.yaml
@@ -4,6 +4,11 @@ info:
   title: Swagger Petstore
   license:
     name: MIT
+  description: |
+    This description is for testing
+    multi-line
+    description
+
 servers:
   - url: http://petstore.swagger.io/v1
 paths:

--- a/tests/data/openapi/default_template/simple.yaml
+++ b/tests/data/openapi/default_template/simple.yaml
@@ -4,6 +4,11 @@ info:
   title: Swagger Petstore
   license:
     name: MIT
+  description: |
+    This description is for testing
+    multi-line
+    description
+
 servers:
   - url: http://petstore.swagger.io/v1
 paths:

--- a/tests/data/openapi/remote_ref/body_and_parameters.yaml
+++ b/tests/data/openapi/remote_ref/body_and_parameters.yaml
@@ -4,6 +4,11 @@ info:
   title: Swagger Petstore
   license:
     name: MIT
+  description: |
+    This description is for testing
+    multi-line
+    description
+
 servers:
   - url: http://petstore.swagger.io/v1
 security:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -34,9 +34,7 @@ def test_generate_default_template(oas_file):
         expected_files = sorted(list(expected_dir.glob('*')))
         assert [f.name for f in output_files] == [f.name for f in expected_files]
         for output_file, expected_file in zip(output_files, expected_files):
-            x = output_file.read_text()
-            print(x)
-            assert x == expected_file.read_text()
+            assert output_file.read_text() == expected_file.read_text()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -34,7 +34,9 @@ def test_generate_default_template(oas_file):
         expected_files = sorted(list(expected_dir.glob('*')))
         assert [f.name for f in output_files] == [f.name for f in expected_files]
         for output_file, expected_file in zip(output_files, expected_files):
-            assert output_file.read_text() == expected_file.read_text()
+            x = output_file.read_text()
+            print(x)
+            assert x == expected_file.read_text()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If the openapi yaml description contains multi-line strings (for instance a nice descriptive 'description' that is written as block text), then using a single-quoted string for this value results in an error when black tries to process the file. Under this example of a long description, you might get something like:

```
black.InvalidInput: Cannot parse: 23:17:     description = "
```

Using triple-quoted strings avoids this.