### PR TITLE
Add the various parameter `in` operators for query, path, header, bod…

### DIFF
--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -308,15 +308,15 @@ class Operation(CachedPropertyModel):
             if has_in and isinstance(has_in, str):
                 param_is = has_in.lower().capitalize()
                 self.imports.append(Import(from_='fastapi', import_=param_is))
+                default: Optional[
+                    str
+                ] = f"{param_is}({'...' if field.required else repr(schema.default)}, alias='{orig_name}')"
             else:
                 # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject
                 # the spec says 'in' is a str type
                 raise TypeError(
                     f'Issue processing parameter for "in", expected a str, but got something else: {str(parameter)}'
                 )
-            default: Optional[
-                str
-            ] = f"{param_is}({'...' if field.required else repr(schema.default)}, alias='{orig_name}')"
         else:
             default = repr(schema.default) if schema.has_default else None
         return Argument(

--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -311,7 +311,7 @@ class Operation(CachedPropertyModel):
             else:
                 # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject
                 # the spec says 'in' is a str type
-                raise ValueError(
+                raise TypeError(
                     f'Issue processing parameter for "in", expected a str, but got something else: {str(parameter)}'
                 )
             default: Optional[

--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -308,13 +308,10 @@ class Operation(CachedPropertyModel):
             if has_in and isinstance(has_in, str):
                 param_is = has_in.lower().capitalize()
                 self.imports.append(Import(from_='fastapi', import_=param_is))
-            elif has_in and isinstance(has_in, dict):
+            else:
                 # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject
                 # the spec says 'in' is a str type
-                pass
-            else:
-                param_is = "Query"
-                self.imports.append(Import(from_='fastapi', import_='Query'))
+                raise ValueError(f'Issue processing parameter for "in", expected a str, but got something else: {str(parameter)}')
             default: Optional[
                 str
             ] = f"{param_is}({'...' if field.required else repr(schema.default)}, alias='{orig_name}')"

--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -305,9 +305,13 @@ class Operation(CachedPropertyModel):
         self.imports.extend(field.imports)
         if orig_name != name:
             has_in = parameter.get('in')
-            if has_in:
+            if has_in and isinstance(has_in, str):
                 param_is = has_in.lower().capitalize()
                 self.imports.append(Import(from_='fastapi', import_=param_is))
+            elif has_in and isinstance(has_in, dict):
+                # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject
+                # the spec says 'in' is a str type
+                pass
             else:
                 param_is = "Query"
                 self.imports.append(Import(from_='fastapi', import_='Query'))

--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -304,10 +304,16 @@ class Operation(CachedPropertyModel):
         )
         self.imports.extend(field.imports)
         if orig_name != name:
+            has_in = parameter.get('in')
+            if has_in:
+                param_is = has_in.lower().capitalize()
+                self.imports.append(Import(from_='fastapi', import_=param_is))
+            else:
+                param_is = "Query"
+                self.imports.append(Import(from_='fastapi', import_='Query'))
             default: Optional[
                 str
-            ] = f"Query({'...' if field.required else repr(schema.default)}, alias='{orig_name}')"
-            self.imports.append(Import(from_='fastapi', import_='Query'))
+            ] = f"{param_is}({'...' if field.required else repr(schema.default)}, alias='{orig_name}')"
         else:
             default = repr(schema.default) if schema.has_default else None
         return Argument(

--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -311,7 +311,9 @@ class Operation(CachedPropertyModel):
             else:
                 # https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject
                 # the spec says 'in' is a str type
-                raise ValueError(f'Issue processing parameter for "in", expected a str, but got something else: {str(parameter)}')
+                raise ValueError(
+                    f'Issue processing parameter for "in", expected a str, but got something else: {str(parameter)}'
+                )
             default: Optional[
                 str
             ] = f"{param_is}({'...' if field.required else repr(schema.default)}, alias='{orig_name}')"

--- a/tests/data/expected/openapi/custom_template_security/custom_security/main.py
+++ b/tests/data/expected/openapi/custom_template_security/custom_security/main.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Path, Query
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette import status
 
@@ -66,14 +66,14 @@ def post_pets(body: PetForm, user: User = Depends(valid_current_user)) -> None:
 
 @app.get('/pets/{pet_id}', response_model=Pet, tags=['pets'])
 def show_pet_by_id(
-    pet_id: str = Query(..., alias='petId'), user: User = Depends(valid_current_user)
+    pet_id: str = Path(..., alias='petId'), user: User = Depends(valid_current_user)
 ) -> Pet:
     pass
 
 
 @app.put('/pets/{pet_id}', response_model=None, tags=['pets'])
 def put_pets_pet_id(
-    pet_id: str = Query(..., alias='petId'),
+    pet_id: str = Path(..., alias='petId'),
     body: PetForm = None,
     user: User = Depends(valid_current_user),
 ) -> None:

--- a/tests/data/expected/openapi/default_template/body_and_parameters/main.py
+++ b/tests/data/expected/openapi/default_template/body_and_parameters/main.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Path, Query
 from starlette.requests import Request
 
 from .models import (
@@ -78,7 +78,7 @@ def post_pets(body: PetForm) -> None:
 
 
 @app.get('/pets/{pet_id}', response_model=Pet)
-def show_pet_by_id(pet_id: str = Query(..., alias='petId')) -> Pet:
+def show_pet_by_id(pet_id: str = Path(..., alias='petId')) -> Pet:
     """
     Info for a specific pet
     """
@@ -87,7 +87,7 @@ def show_pet_by_id(pet_id: str = Query(..., alias='petId')) -> Pet:
 
 @app.put('/pets/{pet_id}', response_model=None)
 def put_pets_pet_id(
-    pet_id: str = Query(..., alias='petId'), body: PetForm = None
+    pet_id: str = Path(..., alias='petId'), body: PetForm = None
 ) -> None:
     """
     update a pet

--- a/tests/data/expected/openapi/default_template/simple/main.py
+++ b/tests/data/expected/openapi/default_template/simple/main.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Path
 
 from .models import Pets
 
@@ -35,7 +35,7 @@ def create_pets() -> None:
 
 
 @app.get('/pets/{pet_id}', response_model=Pets)
-def show_pet_by_id(pet_id: str = Query(..., alias='petId')) -> Pets:
+def show_pet_by_id(pet_id: str = Path(..., alias='petId')) -> Pets:
     """
     Info for a specific pet
     """

--- a/tests/data/expected/openapi/remote_ref/body_and_parameters/main.py
+++ b/tests/data/expected/openapi/remote_ref/body_and_parameters/main.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Path, Query
 
 from .models import Pet, PetForm
 
@@ -62,7 +62,7 @@ def post_pets(body: PetForm) -> None:
 
 
 @app.get('/pets/{pet_id}', response_model=Pet)
-def show_pet_by_id(pet_id: str = Query(..., alias='petId')) -> Pet:
+def show_pet_by_id(pet_id: str = Path(..., alias='petId')) -> Pet:
     """
     Info for a specific pet
     """
@@ -71,7 +71,7 @@ def show_pet_by_id(pet_id: str = Query(..., alias='petId')) -> Pet:
 
 @app.put('/pets/{pet_id}', response_model=None)
 def put_pets_pet_id(
-    pet_id: str = Query(..., alias='petId'), body: PetForm = None
+    pet_id: str = Path(..., alias='petId'), body: PetForm = None
 ) -> None:
     """
     update a pet


### PR DESCRIPTION
…y, form

For example, something like:

```
  parameters:
    x_org:
      name: x-org
      in: header
      description: list of organization ids
      required: false
      schema:
        type: array
        items:
          type: integer
          format: int32
    x_org_query:
      name: x-org-query
      in: query
      description: list of organization ids in the query
      required: false
      schema:
        type: array
        items:
          type: integer
          format: int32
    x_org_body:
      name: x-org-body
      in: body
      description: list of organization ids in the body
      required: false
      schema:
        type: array
        items:
          type: integer
          format: int32
```