### PR TITLE
Enable custom visitors when enum_field_as_literal parameter is passed

### DIFF
--- a/fastapi_code_generator/__main__.py
+++ b/fastapi_code_generator/__main__.py
@@ -62,6 +62,7 @@ def main(
             template_dir,
             model_path,
             enum_field_as_literal,
+            custom_visitors=custom_visitors,
             disable_timestamp=disable_timestamp,
         )
     return generate_code(


### PR DESCRIPTION
`custom_visitors` parameter was not passed to the `generate_code` function when `enum_field_as_literal` parameter was passed.