### PR TITLE
Fix parameter field name

### DIFF
--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -262,11 +262,12 @@ class OpenAPIParser(OpenAPIModelParser):
         path: List[str],
     ) -> Optional[Argument]:
         parameters = self.resolve_object(parameters, ParameterObject)
+        if parameters.name is None:
+            raise RuntimeError("parameters.name is None")  # pragma: no cover
         orig_name = parameters.name
+        name = self.model_resolver.get_valid_field_name(parameters.name)
         if snake_case:
-            name = stringcase.snakecase(parameters.name)
-        else:
-            name = parameters.name
+            name = stringcase.snakecase(name)
 
         schema: Optional[JsonSchemaObject] = None
         data_type: Optional[DataType] = None
@@ -307,8 +308,6 @@ class OpenAPIParser(OpenAPIModelParser):
             default = repr(schema.default) if schema.has_default else None
         self.imports_for_fastapi.append(field.imports)
         self.data_types.append(field.data_type)
-        if field.name is None:
-            raise RuntimeError("field.name is None")  # pragma: no cover
         return Argument(
             name=UsefulStr(field.name),
             type_hint=UsefulStr(field.type_hint),


### PR DESCRIPTION
This PR fixes an invalid field name.

The example below defines the parameter `users[]`, which is not a valid argument name in Python.
This PR will resolve `users[]` as `users__`.

```yaml
parameters:
  - name: users[]
    in: query
    style: form
    explode: false
    schema:
      type: array
      items:
        type: integer
```