### PR TITLE
Update datamodel-code-generator from 0.25.6 to 0.25.9

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1095,4 +1095,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "54ecaa65f8463c6d831b9d8a97b3d98bfb37b8629edc576378d813d4bde369f3"
+content-hash = "c56ece5bd8d177c0b734ae865ed0fa13b4e08f73fae8a6ddb8bbc2b07adfeda8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -201,13 +201,13 @@ toml = ["tomli"]
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.25.6"
+version = "0.25.9"
 description = "Datamodel Code Generator"
 optional = false
 python-versions = "<4.0,>=3.7"
 files = [
-    {file = "datamodel_code_generator-0.25.6-py3-none-any.whl", hash = "sha256:adbdb485a713a7035d7260c28d3f280e598b0eb3170d2361cb92431a44c4d154"},
-    {file = "datamodel_code_generator-0.25.6.tar.gz", hash = "sha256:466f56de876947b73d4a4cd0c947ce37f63f68f2f6c0ce1477045d1e6e495da5"},
+    {file = "datamodel_code_generator-0.25.9-py3-none-any.whl", hash = "sha256:9e0324233123d6e39a35bc0004771956935889a974aacfd7a0651de11d2219a9"},
+    {file = "datamodel_code_generator-0.25.9.tar.gz", hash = "sha256:65ca9807d8edbd88a7f7931c10f4bc1c08bd9bbc5bb0508418a2b6a16590eb65"},
 ]
 
 [package.dependencies]
@@ -1082,4 +1082,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "1dde0ee3e737caa06ec9e4a09ac1e5c628a2bf0eba5c7d8e2bb2eaa5bfee0ccf"
+content-hash = "54ecaa65f8463c6d831b9d8a97b3d98bfb37b8629edc576378d813d4bde369f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ fastapi-codegen = "fastapi_code_generator.__main__:app"
 [tool.poetry.dependencies]
 python = "^3.8.0"
 typer = {extras = ["all"], version = ">=0.2.1,<0.13.0"}
-datamodel-code-generator =  {extras = ["http"], version = "0.25.6"}
+datamodel-code-generator =  {extras = ["http"], version = "0.25.9"}
 stringcase = "^1.2.0"
 PySnooper = ">=0.4.1,<1.2.0"
 jinja2 = ">=2.11.2,<4.0.0"


### PR DESCRIPTION
I'm facing conflict in version when I need to use both `fastapi-code-generator` and `datamodel-code-generator`

The `datamodel-code-generator` is able to generate models with "dot" in their names (output to a folder), however when I use `fastapi-code-generator`, I hit issue `Modular references are not supported in this version`.

I couldn't get it fixed and decided to use datamodel-code to generate model and fastapi-code to generate for the routes separately.

I'm not entirely sure how to allow fastapi-code-generator to adopt the same, happy to contribute if any guidance can be provided.