### PR TITLE
fix: Allow hyphen in tags

### DIFF
--- a/fastapi_code_generator/__main__.py
+++ b/fastapi_code_generator/__main__.py
@@ -20,7 +20,7 @@ app = typer.Typer()
 
 all_tags = []
 
-TITLE_PATTERN = re.compile(r'(?<!^)(?<![A-Z ])(?=[A-Z])| ')
+TITLE_PATTERN = re.compile(r'(?<!^)(?<![A-Z ])(?=[A-Z])| |-')
 
 BUILTIN_MODULAR_TEMPLATE_DIR = Path(__file__).parent / "modular_template"
 


### PR DESCRIPTION
When generating routers and a tag in the openapi spec file contains a hyphen, the python package will contain the hyphen, causing some issues. This little PR fixes it by replacing the hyphen with _ so "my-api" will become "my_api".