### PR TITLE
Preserve router path parameter names

### DIFF
--- a/fastapi_code_generator/modular_template/routers.jinja2
+++ b/fastapi_code_generator/modular_template/routers.jinja2
@@ -10,7 +10,7 @@ router = APIRouter(
 
 {% for operation in operations %}
 {% if operation.tags[0] == tag %}
-@router.{{operation.type}}('{{operation.snake_case_path}}', response_model={{operation.response}}
+@router.{{operation.type}}('{{operation.path}}', response_model={{operation.response}}
     {% if operation.additional_responses %}
         , responses={
             {% for status_code, models in operation.additional_responses.items() %}

--- a/tests/data/expected/openapi/modify_specific_routers/expected/using_routers_example/routers/fat_cats.py
+++ b/tests/data/expected/openapi/modify_specific_routers/expected/using_routers_example/routers/fat_cats.py
@@ -27,7 +27,7 @@ def create_fat_cats() -> None:
     pass
 
 
-@router.get('/cats/{cat_id}', response_model=Pet, tags=['Fat Cats'])
+@router.get('/cats/{catId}', response_model=Pet, tags=['Fat Cats'])
 def show_cat_by_id(cat_id: str = Path(..., alias='catId')) -> Pet:
     """
     Info For a Specific Cat

--- a/tests/data/expected/openapi/modify_specific_routers/expected/using_routers_example/routers/wild_boars.py
+++ b/tests/data/expected/openapi/modify_specific_routers/expected/using_routers_example/routers/wild_boars.py
@@ -27,7 +27,7 @@ def create_wild_boars() -> None:
     pass
 
 
-@router.get('/boars/{boar_id}', response_model=Pet, tags=['Wild Boars'])
+@router.get('/boars/{boarId}', response_model=Pet, tags=['Wild Boars'])
 def show_boar_by_id(boar_id: str = Path(..., alias='boarId')) -> Pet:
     """
     Info For a Specific Boar

--- a/tests/data/expected/openapi/using_routers/using_routers_example/routers/fat_cats.py
+++ b/tests/data/expected/openapi/using_routers/using_routers_example/routers/fat_cats.py
@@ -27,7 +27,7 @@ def create_fat_cats() -> None:
     pass
 
 
-@router.get('/cats/{cat_id}', response_model=Pet, tags=['Fat Cats'])
+@router.get('/cats/{catId}', response_model=Pet, tags=['Fat Cats'])
 def show_cat_by_id(cat_id: str = Path(..., alias='catId')) -> Pet:
     """
     Info For a Specific Cat

--- a/tests/data/expected/openapi/using_routers/using_routers_example/routers/slim_dogs.py
+++ b/tests/data/expected/openapi/using_routers/using_routers_example/routers/slim_dogs.py
@@ -27,7 +27,7 @@ def create_slim_dogs() -> None:
     pass
 
 
-@router.get('/dogs/{dog_id}', response_model=Pet, tags=['Slim Dogs'])
+@router.get('/dogs/{dogId}', response_model=Pet, tags=['Slim Dogs'])
 def show_dog_by_id(dog_id: str = Path(..., alias='dogId')) -> Pet:
     """
     Info For a Specific Dog

--- a/tests/data/expected/openapi/using_routers/using_routers_example/routers/wild_boars.py
+++ b/tests/data/expected/openapi/using_routers/using_routers_example/routers/wild_boars.py
@@ -27,7 +27,7 @@ def create_wild_boars() -> None:
     pass
 
 
-@router.get('/boars/{boar_id}', response_model=Pet, tags=['Wild Boars'])
+@router.get('/boars/{boarId}', response_model=Pet, tags=['Wild Boars'])
 def show_boar_by_id(boar_id: str = Path(..., alias='boarId')) -> Pet:
     """
     Info For a Specific Boar

--- a/tests/data/modular_template/routers.jinja2
+++ b/tests/data/modular_template/routers.jinja2
@@ -10,7 +10,7 @@ router = APIRouter(
 
 {% for operation in operations %}
 {% if operation.tags[0] == tag %}
-@router.{{operation.type}}('{{operation.snake_case_path}}', response_model={{operation.response}}
+@router.{{operation.type}}('{{operation.path}}', response_model={{operation.response}}
     {% if operation.additional_responses %}
         , responses={
             {% for status_code, models in operation.additional_responses.items() %}

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -443,8 +443,11 @@ def test_generate_router_preserves_path_parameter_name(output_dir: Path) -> None
     )
 
     router_text = output_dir.joinpath("routers", "items.py").read_text(encoding="utf-8")
+    main_text = output_dir.joinpath("main.py").read_text(encoding="utf-8")
     assert "@router.get('/items/{itemId}', response_model=None" in router_text
     assert "item_id: str = Path(..., alias='itemId')" in router_text
+    assert "from .routers import items" in main_text
+    assert "app.include_router(items.router)" in main_text
     validate_generated_code(output_dir)
 
 

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -407,6 +407,49 @@ def test_generate_router_name_from_hyphenated_tag(output_dir: Path) -> None:
     validate_generated_code(output_dir)
 
 
+def test_generate_router_preserves_path_parameter_name(output_dir: Path) -> None:
+    spec = json.dumps(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Example", "version": "1.0.0"},
+            "paths": {
+                "/items/{itemId}": {
+                    "get": {
+                        "operationId": "getItem",
+                        "tags": ["Items"],
+                        "parameters": [
+                            {
+                                "name": "itemId",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string"},
+                            }
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+
+    generate_code(
+        "camel_path_parameter.yaml",
+        spec,
+        "utf-8",
+        output_dir,
+        BUILTIN_MODULAR_TEMPLATE_DIR,
+        disable_timestamp=True,
+        generate_routers=True,
+    )
+
+    router_text = output_dir.joinpath("routers", "items.py").read_text(
+        encoding="utf-8"
+    )
+    assert "@router.get('/items/{itemId}', response_model=None" in router_text
+    assert "item_id: str = Path(..., alias='itemId')" in router_text
+    validate_generated_code(output_dir)
+
+
 @pytest.mark.cli_doc(
     options=["--specify-tags"],
     option_description="Regenerate only the routers matching a comma-separated tag list.",

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -442,9 +442,7 @@ def test_generate_router_preserves_path_parameter_name(output_dir: Path) -> None
         generate_routers=True,
     )
 
-    router_text = output_dir.joinpath("routers", "items.py").read_text(
-        encoding="utf-8"
-    )
+    router_text = output_dir.joinpath("routers", "items.py").read_text(encoding="utf-8")
     assert "@router.get('/items/{itemId}', response_model=None" in router_text
     assert "item_id: str = Path(..., alias='itemId')" in router_text
     validate_generated_code(output_dir)


### PR DESCRIPTION
Fixes: https://github.com/koxudaxi/fastapi-code-generator/issues/487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FastAPI route path generation to correctly preserve original path parameter names (e.g., camelCase) instead of converting them to snake_case in URL templates. Function parameters and aliases remain properly mapped.

* **Tests**
  * Added test case validating camelCase path parameters in modular router generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->