### PR TITLE
Fix specify-tags router filtering

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -119,7 +119,7 @@ Input schema: `openapi/using_routers/using_routers_example.yaml`
 
 ### --specify-tags
 
-Regenerate only the routers matching a comma-separated tag list.
+Generate or regenerate only the routers matching a comma-separated tag list.
 
 `fastapi-codegen --input openapi/using_routers/using_routers_example.yaml --output app --template-dir modular_template --generate-routers --specify-tags Wild Boars, Fat Cats`
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -445,7 +445,7 @@ Input schema: `openapi/using_routers/using_routers_example.yaml`
 
 ### --specify-tags
 
-Regenerate only the routers matching a comma-separated tag list.
+Generate or regenerate only the routers matching a comma-separated tag list.
 
 `fastapi-codegen --input openapi/using_routers/using_routers_example.yaml --output app --template-dir modular_template --generate-routers --specify-tags Wild Boars, Fat Cats`
 

--- a/fastapi_code_generator/cli.py
+++ b/fastapi_code_generator/cli.py
@@ -277,7 +277,7 @@ def generate_code(
     # Convert from Tag Names to router_names
     sorted_tags = sorted(set(all_tags), key=lambda x: x.lower())
     routers = [re.sub(TITLE_PATTERN, '_', tag.strip()).lower() for tag in sorted_tags]
-    router_tag_pairs = list(zip(routers, sorted_tags))
+    router_tag_pairs = list(zip(routers, sorted_tags, strict=True))
     specified_tags = set()
     existing_main_has_router_includes = False
     if generate_routers and specify_tags:

--- a/fastapi_code_generator/cli.py
+++ b/fastapi_code_generator/cli.py
@@ -276,14 +276,14 @@ def generate_code(
                     all_tags.append(tag)
     # Convert from Tag Names to router_names
     sorted_tags = sorted(set(all_tags), key=lambda x: x.lower())
-    routers = sorted(
-        [re.sub(TITLE_PATTERN, '_', tag.strip()).lower() for tag in sorted_tags]
-    )
+    routers = [re.sub(TITLE_PATTERN, '_', tag.strip()).lower() for tag in sorted_tags]
     router_tag_pairs = list(zip(routers, sorted_tags))
     specified_tags = set()
     existing_main_has_router_includes = False
     if generate_routers and specify_tags:
-        specified_tags = {tag.strip() for tag in str(specify_tags).split(",")}
+        specified_tags = {
+            tag.strip() for tag in str(specify_tags).split(",") if tag.strip()
+        }
         main_path = output_dir / "main.py"
         if main_path.exists():
             existing_main_has_router_includes = (
@@ -295,6 +295,13 @@ def generate_code(
         main_router_tag_pairs = [
             (router, tag) for router, tag in router_tag_pairs if tag in specified_tags
         ]
+        if not main_router_tag_pairs:
+            available = ", ".join(tag for _, tag in router_tag_pairs) or "<none>"
+            requested = ", ".join(sorted(specified_tags))
+            raise ClickException(
+                f"No routers matched --specify-tags ({requested}). "
+                f"Available tags: {available}"
+            )
 
     template_vars = {
         **template_vars,

--- a/fastapi_code_generator/cli.py
+++ b/fastapi_code_generator/cli.py
@@ -279,7 +279,28 @@ def generate_code(
     routers = sorted(
         [re.sub(TITLE_PATTERN, '_', tag.strip()).lower() for tag in sorted_tags]
     )
-    template_vars = {**template_vars, "routers": routers, "tags": sorted_tags}
+    router_tag_pairs = list(zip(routers, sorted_tags))
+    specified_tags = set()
+    existing_main_has_router_includes = False
+    if generate_routers and specify_tags:
+        specified_tags = {tag.strip() for tag in str(specify_tags).split(",")}
+        main_path = output_dir / "main.py"
+        if main_path.exists():
+            existing_main_has_router_includes = (
+                "app.include_router" in main_path.read_text(encoding=encoding)
+            )
+
+    main_router_tag_pairs = router_tag_pairs
+    if specified_tags and not existing_main_has_router_includes:
+        main_router_tag_pairs = [
+            (router, tag) for router, tag in router_tag_pairs if tag in specified_tags
+        ]
+
+    template_vars = {
+        **template_vars,
+        "routers": [router for router, _ in main_router_tag_pairs],
+        "tags": [tag for _, tag in main_router_tag_pairs],
+    }
 
     for target in template_dir.rglob("*"):
         relative_path = target.relative_to(template_dir)
@@ -290,25 +311,20 @@ def generate_code(
         )
 
     if generate_routers:
-        tags = sorted_tags
         results.pop(Path("routers.jinja2"), None)
-        if specify_tags:
-            if Path(output_dir.joinpath("main.py")).exists():
-                with open(Path(output_dir.joinpath("main.py")), 'r') as file:
-                    content = file.read()
-                    if "app.include_router" in content:
-                        tags = sorted(
-                            set(tag.strip() for tag in str(specify_tags).split(","))
-                        )
+        router_pairs = router_tag_pairs
+        if specified_tags and not existing_main_has_router_includes:
+            router_pairs = main_router_tag_pairs
 
         for target in template_dir.rglob("routers.*"):
             relative_path = target.relative_to(template_dir)
-            for router, tag in zip(routers, sorted_tags):
+            for router, tag in router_pairs:
                 if (
                     not Path(output_dir.joinpath("routers", router))
                     .with_suffix(".py")
                     .exists()
-                    or tag in tags
+                    or not specified_tags
+                    or tag in specified_tags
                 ):
                     template_vars["tag"] = tag.strip()
                     template = environment.get_template(str(relative_path))

--- a/fastapi_code_generator/prompt_data.py
+++ b/fastapi_code_generator/prompt_data.py
@@ -302,7 +302,7 @@ PROMPT_DATA: dict[str, Any] = {
         },
         {
             'options': ['--specify-tags'],
-            'description': 'Regenerate only the routers matching a '
+            'description': 'Generate or regenerate only the routers matching a '
             'comma-separated tag list.',
             'cli_args': [
                 '--input',

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -683,11 +683,44 @@ def test_generate_specific_tags_with_existing_main_without_router_includes(
 
     main_text = output_dir.joinpath("main.py").read_text(encoding="utf-8")
     assert "from .routers import fat_cats, wild_boars" in main_text
+    assert "app.include_router(fat_cats.router)" in main_text
+    assert "app.include_router(wild_boars.router)" in main_text
     assert "slim_dogs" not in main_text
     assert output_dir.joinpath("routers", "fat_cats.py").exists()
     assert output_dir.joinpath("routers", "wild_boars.py").exists()
     assert not output_dir.joinpath("routers", "slim_dogs.py").exists()
     validate_generated_code(output_dir)
+
+
+def test_generate_specific_tags_without_matching_tag(
+    capsys: pytest.CaptureFixture[str], output_dir: Path
+) -> None:
+    assert (
+        run_main_with_args(
+            [
+                "--input",
+                str(
+                    DATA_PATH
+                    / OPEN_API_USING_ROUTERS_DIR_NAME
+                    / "using_routers_example.yaml"
+                ),
+                "--output",
+                str(output_dir),
+                "--template-dir",
+                str(BUILTIN_MODULAR_TEMPLATE_DIR),
+                "--generate-routers",
+                "--specify-tags",
+                "Missing Tag",
+            ]
+        )
+        == 1
+    )
+
+    assert (
+        "No routers matched --specify-tags (Missing Tag). "
+        "Available tags: Fat Cats, Slim Dogs, Wild Boars"
+    ) in capsys.readouterr().err
+    assert not output_dir.joinpath("main.py").exists()
 
 
 @freeze_time("2020-06-19")

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -571,7 +571,7 @@ def test_generate_router_preserves_path_parameter_name(output_dir: Path) -> None
 
 @pytest.mark.cli_doc(
     options=["--specify-tags"],
-    option_description="Regenerate only the routers matching a comma-separated tag list.",
+    option_description="Generate or regenerate only the routers matching a comma-separated tag list.",
     cli_args=[
         "--input",
         "openapi/using_routers/using_routers_example.yaml",
@@ -619,20 +619,36 @@ def test_generate_modify_specific_routers(oas_file: Path, output_dir: Path) -> N
 
 @freeze_time("2023-04-11")
 def test_generate_specific_tags_without_existing_main(output_dir: Path) -> None:
-    run_cli_and_assert(
-        input_path=DATA_PATH
-        / OPEN_API_USING_ROUTERS_DIR_NAME
-        / "using_routers_example.yaml",
-        output_path=output_dir,
-        expected_path=EXPECTED_OPENAPI_PATH / "using_routers" / "using_routers_example",
-        extra_args=[
-            "--template-dir",
-            str(BUILTIN_MODULAR_TEMPLATE_DIR),
-            "--generate-routers",
-            "--specify-tags",
-            SPECIFIC_TAGS,
-        ],
+    assert (
+        run_main_with_args(
+            [
+                "--input",
+                str(
+                    DATA_PATH
+                    / OPEN_API_USING_ROUTERS_DIR_NAME
+                    / "using_routers_example.yaml"
+                ),
+                "--output",
+                str(output_dir),
+                "--template-dir",
+                str(BUILTIN_MODULAR_TEMPLATE_DIR),
+                "--generate-routers",
+                "--specify-tags",
+                SPECIFIC_TAGS,
+            ]
+        )
+        == 0
     )
+
+    main_text = output_dir.joinpath("main.py").read_text(encoding="utf-8")
+    assert "from .routers import fat_cats, wild_boars" in main_text
+    assert "app.include_router(fat_cats.router)" in main_text
+    assert "app.include_router(wild_boars.router)" in main_text
+    assert "slim_dogs" not in main_text
+    assert output_dir.joinpath("routers", "fat_cats.py").exists()
+    assert output_dir.joinpath("routers", "wild_boars.py").exists()
+    assert not output_dir.joinpath("routers", "slim_dogs.py").exists()
+    validate_generated_code(output_dir)
 
 
 @freeze_time("2023-04-11")
@@ -644,20 +660,34 @@ def test_generate_specific_tags_with_existing_main_without_router_includes(
         "from fastapi import FastAPI\n\napp = FastAPI()\n",
         encoding="utf-8",
     )
-    run_cli_and_assert(
-        input_path=DATA_PATH
-        / OPEN_API_USING_ROUTERS_DIR_NAME
-        / "using_routers_example.yaml",
-        output_path=output_dir,
-        expected_path=EXPECTED_OPENAPI_PATH / "using_routers" / "using_routers_example",
-        extra_args=[
-            "--template-dir",
-            str(BUILTIN_MODULAR_TEMPLATE_DIR),
-            "--generate-routers",
-            "--specify-tags",
-            SPECIFIC_TAGS,
-        ],
+    assert (
+        run_main_with_args(
+            [
+                "--input",
+                str(
+                    DATA_PATH
+                    / OPEN_API_USING_ROUTERS_DIR_NAME
+                    / "using_routers_example.yaml"
+                ),
+                "--output",
+                str(output_dir),
+                "--template-dir",
+                str(BUILTIN_MODULAR_TEMPLATE_DIR),
+                "--generate-routers",
+                "--specify-tags",
+                SPECIFIC_TAGS,
+            ]
+        )
+        == 0
     )
+
+    main_text = output_dir.joinpath("main.py").read_text(encoding="utf-8")
+    assert "from .routers import fat_cats, wild_boars" in main_text
+    assert "slim_dogs" not in main_text
+    assert output_dir.joinpath("routers", "fat_cats.py").exists()
+    assert output_dir.joinpath("routers", "wild_boars.py").exists()
+    assert not output_dir.joinpath("routers", "slim_dogs.py").exists()
+    validate_generated_code(output_dir)
 
 
 @freeze_time("2020-06-19")

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -33,6 +33,18 @@ BUILTIN_MODULAR_TEMPLATE_DIR = DATA_PATH / "modular_template"
 SPECIFIC_TAGS = "Wild Boars, Fat Cats"
 
 
+def assert_specific_tag_routers_generated(output_dir: Path) -> None:
+    main_text = output_dir.joinpath("main.py").read_text(encoding="utf-8")
+    assert "from .routers import fat_cats, wild_boars" in main_text
+    assert "app.include_router(fat_cats.router)" in main_text
+    assert "app.include_router(wild_boars.router)" in main_text
+    assert "slim_dogs" not in main_text
+    assert output_dir.joinpath("routers", "fat_cats.py").exists()
+    assert output_dir.joinpath("routers", "wild_boars.py").exists()
+    assert not output_dir.joinpath("routers", "slim_dogs.py").exists()
+    validate_generated_code(output_dir)
+
+
 @pytest.mark.cli_doc(
     options=["--help"],
     option_description="Show the CLI help message.",
@@ -640,15 +652,7 @@ def test_generate_specific_tags_without_existing_main(output_dir: Path) -> None:
         == 0
     )
 
-    main_text = output_dir.joinpath("main.py").read_text(encoding="utf-8")
-    assert "from .routers import fat_cats, wild_boars" in main_text
-    assert "app.include_router(fat_cats.router)" in main_text
-    assert "app.include_router(wild_boars.router)" in main_text
-    assert "slim_dogs" not in main_text
-    assert output_dir.joinpath("routers", "fat_cats.py").exists()
-    assert output_dir.joinpath("routers", "wild_boars.py").exists()
-    assert not output_dir.joinpath("routers", "slim_dogs.py").exists()
-    validate_generated_code(output_dir)
+    assert_specific_tag_routers_generated(output_dir)
 
 
 @freeze_time("2023-04-11")
@@ -681,15 +685,7 @@ def test_generate_specific_tags_with_existing_main_without_router_includes(
         == 0
     )
 
-    main_text = output_dir.joinpath("main.py").read_text(encoding="utf-8")
-    assert "from .routers import fat_cats, wild_boars" in main_text
-    assert "app.include_router(fat_cats.router)" in main_text
-    assert "app.include_router(wild_boars.router)" in main_text
-    assert "slim_dogs" not in main_text
-    assert output_dir.joinpath("routers", "fat_cats.py").exists()
-    assert output_dir.joinpath("routers", "wild_boars.py").exists()
-    assert not output_dir.joinpath("routers", "slim_dogs.py").exists()
-    validate_generated_code(output_dir)
+    assert_specific_tag_routers_generated(output_dir)
 
 
 def test_generate_specific_tags_without_matching_tag(


### PR DESCRIPTION
Fixes: https://github.com/koxudaxi/fastapi-code-generator/issues/488

## Summary
- Apply `--specify-tags` to modular router imports and generated router files for fresh output directories.
- Preserve the existing partial router regeneration behavior when an existing `main.py` already has router includes.
- Update CLI docs/prompt data and tests for filtered fresh generation.

## Checks
- `tox -e py3.14`
- `tox -e cli-docs -- --check`
- `tox -e llms-txt -- --check`
- `tox -e readme`
- `tox -e fix`
- `tox -e type`
- `tox -e config-types`
- `tox -e schema-docs -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the --specify-tags CLI option to generate or regenerate routers for a specified comma-separated tag list.

* **Bug Fixes**
  * If no requested tags match available tags, the CLI exits with an error listing available tags and does not create the main output.

* **Documentation**
  * Updated CLI docs/help to reflect the generate-or-regenerate wording for --specify-tags.

* **Tests**
  * Added and refactored tests to validate tag-based generation, exclusion of non-selected tags, and the no-match error case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->