### PR TITLE
Fix stringcase dependency with setuptools 78.0.0

### DIFF
--- a/fastapi_code_generator/parser.py
+++ b/fastapi_code_generator/parser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import re
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import (
     Any,
     Callable,
@@ -11,6 +11,7 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    Match,
     Optional,
     Pattern,
     Sequence,
@@ -20,7 +21,6 @@ from typing import (
 )
 from urllib.parse import ParseResult
 
-import stringcase
 from datamodel_code_generator import (
     DefaultPutDict,
     LiteralType,
@@ -47,6 +47,59 @@ from datamodel_code_generator.types import DataType, DataTypeManager
 from pydantic import BaseModel, ConfigDict, ValidationInfo
 
 RE_APPLICATION_JSON_PATTERN: Pattern[str] = re.compile(r'^application/.*json$')
+RE_SNAKECASE_REPLACE_PATTERN: Pattern[str] = re.compile(r"[\-\.\s]")
+RE_UPPERCASE_PATTERN: Pattern[str] = re.compile(r"[A-Z]")
+RE_CAMELCASE_STRIP_PATTERN: Pattern[str] = re.compile(r"\w[\s\W]+\w")
+RE_CAMELCASE_REPLACE_PATTERN: Pattern[str] = re.compile(r"[\-_\.\s]([a-z])")
+
+
+def _underscore_lowercase(match: Match[str]) -> str:
+    return '_' + match.group(0).lower()
+
+
+def _uppercase_group(match: Match[str]) -> str:
+    return match.group(1).upper()
+
+
+@lru_cache(maxsize=2048)
+def _snakecase_string(value: str) -> str:
+    string = RE_SNAKECASE_REPLACE_PATTERN.sub('_', value)
+    if not string:
+        return string
+    return string[0].lower() + RE_UPPERCASE_PATTERN.sub(
+        _underscore_lowercase, string[1:]
+    )
+
+
+@lru_cache(maxsize=2048)
+def _camelcase_string(value: str) -> str:
+    string = RE_CAMELCASE_STRIP_PATTERN.sub('', value)
+    if not string:
+        return string
+    return string[0].lower() + RE_CAMELCASE_REPLACE_PATTERN.sub(
+        _uppercase_group,
+        string[1:],
+    )
+
+
+@lru_cache(maxsize=2048)
+def _pascalcase_string(value: str) -> str:
+    string = _camelcase_string(value)
+    if not string:
+        return string
+    return string[0].upper() + string[1:]
+
+
+def snakecase(value: object) -> str:
+    return _snakecase_string(str(value))
+
+
+def camelcase(value: object) -> str:
+    return _camelcase_string(str(value))
+
+
+def pascalcase(value: object) -> str:
+    return _pascalcase_string(str(value))
 
 
 class CachedPropertyModel(BaseModel):
@@ -78,15 +131,15 @@ class UsefulStr(str):
 
     @property
     def snakecase(self) -> str:  # pragma: no cover
-        return stringcase.snakecase(self)
+        return snakecase(self)
 
     @property
     def pascalcase(self) -> str:  # pragma: no cover
-        return stringcase.pascalcase(self)
+        return pascalcase(self)
 
     @property
     def camelcase(self) -> str:  # pragma: no cover
-        return stringcase.camelcase(self)
+        return camelcase(self)
 
 
 class Argument(CachedPropertyModel):
@@ -123,8 +176,8 @@ class Argument(CachedPropertyModel):
     def snakecase(self) -> str:
         type_hint = self.resolved_type_hint
         if self.default is None and self.required:
-            return f'{stringcase.snakecase(self.name)}: {type_hint}'
-        return f'{stringcase.snakecase(self.name)}: {type_hint} = {self.default}'
+            return f'{snakecase(self.name)}: {type_hint}'
+        return f'{snakecase(self.name)}: {type_hint} = {self.default}'
 
     @property
     def plain_parameter(self) -> str:
@@ -204,7 +257,7 @@ class Operation(CachedPropertyModel):
     @property
     def plain_arguments(self) -> str:
         return ", ".join(
-            stringcase.snakecase(argument.name) for argument in self._merged_arguments
+            snakecase(argument.name) for argument in self._merged_arguments
         )
 
     @property
@@ -231,9 +284,7 @@ class Operation(CachedPropertyModel):
 
     @cached_property
     def snake_case_path(self) -> str:
-        return re.sub(
-            r"{([^\}]+)}", lambda m: stringcase.snakecase(m.group()), self.path
-        )
+        return re.sub(r"{([^\}]+)}", lambda m: snakecase(m.group()), self.path)
 
     @cached_property
     def function_name(self) -> str:
@@ -242,7 +293,7 @@ class Operation(CachedPropertyModel):
         else:
             path = re.sub(r'/{|/', '_', self.snake_case_path).replace('}', '')
             name = f"{self.type}{path}"
-        return stringcase.snakecase(name)
+        return snakecase(name)
 
 
 @snooper_to_methods()
@@ -373,7 +424,7 @@ class OpenAPIParser(OpenAPIModelParser):
         orig_name = parameters.name
         name = self.model_resolver.get_valid_field_name(parameters.name)
         if snake_case:  # pragma: no branch
-            name = stringcase.snakecase(name)
+            name = snakecase(name)
 
         schema: Optional[JsonSchemaObject] = None
         data_type: Optional[DataType] = None
@@ -593,7 +644,7 @@ class OpenAPIParser(OpenAPIModelParser):
                 if self._is_upload_file_array(
                     property_schema
                 ) or self._is_upload_file_schema(property_schema):
-                    return stringcase.snakecase(
+                    return snakecase(
                         self.model_resolver.get_valid_field_name(property_name)
                     )
         return 'file'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
   "jinja2>=2.11.2,<4",
   "pydantic>=2.12,<3",
   "pysnooper>=0.4.1,<2",
-  "stringcase>=1.2,<2",
   "typer>=0.12,<1",
 ]
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,44 @@ import pytest
 from datamodel_code_generator.parser.jsonschema import JsonSchemaObject
 from datamodel_code_generator.parser.openapi import ReferenceObject, RequestBodyObject
 
-from fastapi_code_generator.parser import OpenAPIParser
+from fastapi_code_generator.parser import OpenAPIParser, UsefulStr, snakecase
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("listPets", "list_pets"),
+        ("pet-id", "pet_id"),
+        ("pet.id", "pet_id"),
+        ("pet id", "pet_id"),
+        ("{petId}", "{pet_id}"),
+        ("HTTPStatus", "h_t_t_p_status"),
+        ("", ""),
+    ],
+)
+def test_snakecase_matches_legacy_stringcase_behavior(
+    value: str, expected: str
+) -> None:
+    assert snakecase(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_snake", "expected_camel", "expected_pascal"),
+    [
+        ("sample_name", "sample_name", "sampleName", "SampleName"),
+        ("listPets", "list_pets", "listPets", "ListPets"),
+        ("SampleName", "sample_name", "sampleName", "SampleName"),
+        ("", "", "", ""),
+    ],
+)
+def test_useful_str_case_helpers_match_legacy_stringcase_behavior(
+    value: str, expected_snake: str, expected_camel: str, expected_pascal: str
+) -> None:
+    useful_value = UsefulStr(value)
+
+    assert useful_value.snakecase == expected_snake
+    assert useful_value.camelcase == expected_camel
+    assert useful_value.pascalcase == expected_pascal
 
 
 def test_get_upload_file_type_resolves_reference(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -667,7 +667,6 @@ dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },
     { name = "pysnooper" },
-    { name = "stringcase" },
     { name = "typer" },
 ]
 
@@ -740,7 +739,6 @@ requires-dist = [
     { name = "jinja2", specifier = ">=2.11.2,<4" },
     { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "pysnooper", specifier = ">=0.4.1,<2" },
-    { name = "stringcase", specifier = ">=1.2,<2" },
     { name = "typer", specifier = ">=0.12,<1" },
 ]
 
@@ -1843,12 +1841,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
-
-[[package]]
-name = "stringcase"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/1f/1241aa3d66e8dc1612427b17885f5fcd9c9ee3079fc0d28e9a3aeeb36fa3/stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008", size = 2958, upload-time = "2017-08-06T01:40:57.021Z" }
 
 [[package]]
 name = "time-machine"


### PR DESCRIPTION
Fixes: https://github.com/koxudaxi/fastapi-code-generator/issues/481

## Summary
- Replace the runtime use of the unmaintained `stringcase` package with local case conversion helpers for the behavior used by the parser.
- Remove `stringcase` from project dependencies and the uv lockfile.
- Add parser tests that pin the legacy case conversion behavior used in generated operation names, paths, and arguments.

## Checks
- `uv run pytest -q`
- `uv run tox -e fix`
- `uv run tox -e type`
- `uv run tox -e pkg_meta`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced an external string-casing dependency with an internal implementation to centralize and standardize name conversions without changing public interfaces.

* **Tests**
  * Added tests validating legacy casing behavior across varied inputs to ensure consistent snake/camel/pascal conversions and preserve prior outputs.

* **Chores**
  * Removed the now-unused external dependency from project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->