### PR TITLE
Fix release draft label permissions

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -147,7 +147,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
+          gh issue edit ${{ github.event.pull_request.number }} \
             --repo "$GITHUB_REPOSITORY" \
             --add-label "breaking-change-analyzed"
 
@@ -156,7 +156,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
+          gh issue edit ${{ github.event.pull_request.number }} \
             --repo "$GITHUB_REPOSITORY" \
             --add-label "breaking-change"
 
@@ -186,7 +186,7 @@ jobs:
             printf '*This analysis was performed by Claude Code Action*\n'
           } > "$TMPFILE"
 
-          gh pr comment ${{ github.event.pull_request.number }} \
+          gh issue comment ${{ github.event.pull_request.number }} \
             --repo "$GITHUB_REPOSITORY" \
             --body-file "$TMPFILE"
 


### PR DESCRIPTION
## Summary
- Use `gh issue edit` for PR labels so the release draft job works with `issues: write`
- Use `gh issue comment` for the analysis comment without requiring pull request write scope

## Checks
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-draft.yml"); puts "OK release-draft"'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow automation for improved integration with issue tracking and release management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->