### PR TITLE
Use REST API for release draft labels

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -192,9 +192,16 @@ jobs:
             printf '*This analysis was performed by Claude Code Action*\n'
           } > "$TMPFILE"
 
-          gh issue comment ${{ github.event.pull_request.number }} \
-            --repo "$GITHUB_REPOSITORY" \
-            --body-file "$TMPFILE"
+          TMPJSON=$(mktemp)
+          trap 'rm -f "$TMPFILE" "$TMPJSON"' EXIT
+          jq -n --rawfile body "$TMPFILE" '{body: $body}' > "$TMPJSON"
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/comments" \
+            --input "$TMPJSON" \
+            --silent
 
       - name: Calculate version and update draft release
         env:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -147,18 +147,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit ${{ github.event.pull_request.number }} \
-            --repo "$GITHUB_REPOSITORY" \
-            --add-label "breaking-change-analyzed"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" \
+            -f labels[]="breaking-change-analyzed" \
+            --silent
 
       - name: Add breaking-change label if applicable
         if: steps.analysis.outputs.has_breaking_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit ${{ github.event.pull_request.number }} \
-            --repo "$GITHUB_REPOSITORY" \
-            --add-label "breaking-change"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" \
+            -f labels[]="breaking-change" \
+            --silent
 
       - name: Post analysis result to PR
         env:


### PR DESCRIPTION
## Summary
- Add release draft labels through the REST Issues Labels API
- Add release draft analysis comments through the REST Issues Comments API
- Avoid `gh issue edit/comment` CLI wrappers for write operations in the no-checkout update job

## Checks
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-draft.yml"); puts "OK release-draft"'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use direct API calls for applying labels and posting analysis comments, improving reliability and reducing noisy command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->