### PR TITLE
Fix release draft PR label scope

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -110,7 +110,7 @@ jobs:
     permissions:
       contents: write
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Download analysis artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## Summary
- Grant the release draft update job `pull-requests: write` so PR labels can be added by the workflow token
- Keep the no-checkout update job and REST API label/comment calls from the previous fix

## Checks
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-draft.yml"); puts "OK release-draft"'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to support enhanced automation capabilities for release management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->